### PR TITLE
Fix base_path and use relative_url

### DIFF
--- a/_includes/base_path
+++ b/_includes/base_path
@@ -1,5 +1,1 @@
-{% if site.url %}
-  {% assign base_path = site.url | append: site.baseurl %}
-{% else %}
-  {% assign base_path = site.github.url %}
-{% endif %}
+{% assign base_path = site.baseurl | default: "" %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,6 +16,6 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="{{ base_path }}/assets/css/main.css">
+<link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
 
 <meta http-equiv="cleartype" content="on">

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -10,7 +10,7 @@
 <link rel="manifest" href="{{ base_path }}/images/manifest.json"/>
 <link rel="icon" href="/images/favicon.ico"/>
 <meta name="theme-color" content="#ffffff"/>
-<link rel="stylesheet" href="{{ base_path }}/assets/css/academicons.css"/>
+<link rel="stylesheet" href="{{ '/assets/css/academicons.css' | relative_url }}"/>
 
 <!-- Support for MatJax -->
 <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,7 +1,7 @@
 <!-- QUICK WORKAROUND: Add this to _includes/scripts.html -->
 <!-- This bypasses the build system entirely -->
 {% include base_path %}
-<script src="{{ base_path }}/assets/js/main.min.js"></script>
+<script src="{{ '/assets/js/main.min.js' | relative_url }}"></script>
 
 <!-- Direct theme toggle implementation -->
 <script>

--- a/_pages/cv-json.md
+++ b/_pages/cv-json.md
@@ -9,7 +9,7 @@ redirect_from:
 
 {% include base_path %}
 
-<link rel="stylesheet" href="{{ base_path }}/assets/css/cv-style.css">
+<link rel="stylesheet" href="{{ '/assets/css/cv-style.css' | relative_url }}">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
 
 <style>


### PR DESCRIPTION
## Summary
- simplify base_path include to use `site.baseurl`
- load JS/CSS using Jekyll's `relative_url`

## Testing
- `bundle install` *(fails: Bundler cannot fetch gems)*

------
https://chatgpt.com/codex/tasks/task_e_688234e69ccc8331bb080dbfe3c96c50